### PR TITLE
when not using permissions_require_all 

### DIFF
--- a/app/Http/Middleware/PermissionsRequiredMiddleware.php
+++ b/app/Http/Middleware/PermissionsRequiredMiddleware.php
@@ -48,7 +48,7 @@ class PermissionsRequiredMiddleware {
 				return $next($request);
 			}
 		} else {
-			if (count($permissions) > 0)
+			if (count($userPermissions) > 0)
 			{
 				// Allow the request.
 				return $next($request);


### PR DESCRIPTION
Updated so when not using permissions_require_all this counts the user permissions not the actual permissions requested array.
